### PR TITLE
frr-7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,8 @@ RUN set -ex \
  && echo "yes" | mk-build-deps --install debian/control \
  && sed -i '/--enable-bgp-vnc/a --enable-cumulus=yes \\' debian/rules \
  && sed -i '/--enable-bgp-vnc/a --enable-datacenter=yes \\' debian/rules \
- && git config --global user.email "you@example.com" \
- && git config --global user.name "Your Name" \
+ && git config --global user.email "ci@metal-stack.io" \
+ && git config --global user.name "metal stack" \
  && git commit -m "Activate cumulus datacenter defaults." debian/rules \
  && ./tools/tarsource.sh -V \
  && dpkg-buildpackage 1>/dev/null

--- a/docker-make.debian.yaml
+++ b/docker-make.debian.yaml
@@ -10,18 +10,21 @@ default-build-args:
   - LIBYANG_BUILD=00010
   - LIBYANG_BUILD_ID=105-1
 builds:
-  -
-    name: FRR 7.2.1 for Debian 10
+  - name: FRR 7.2.1 for Debian 10
     tags:
       - 7.2.1-debian-10
       - 7.2-debian-10
-      - 7-debian-10
     build-args:
       - FRR_TAG=frr-7.2.1
-  -
-    name: FRR 7.3.1 for Debian 10
+  - name: FRR 7.3.1 for Debian 10
     tags:
       - 7.3.1-debian-10
       - 7.3-debian-10
     build-args:
       - FRR_TAG=frr-7.3.1
+  - name: FRR 7.4.0 for Debian 10
+    tags:
+      - 7.4.0-debian-10
+      - 7.4-debian-10
+    build-args:
+      - FRR_TAG=frr-7.4

--- a/docker-make.ubuntu.yaml
+++ b/docker-make.ubuntu.yaml
@@ -11,33 +11,24 @@ default-build-args:
   - LIBYANG_BUILD=00010
   - LIBYANG_BUILD_ID=105-1
 builds:
-  - name: FRR 7.2.1 for Ubuntu 19.10
-    tags:
-      - 7.2.1-ubuntu-19.10
-      - 7.2-ubuntu-19.10
-    build-args:
-      - FRR_TAG=frr-7.2.1
-  -
-    name: FRR 7.2.1 for Ubuntu 20.04
+  - name: FRR 7.2.1 for Ubuntu 20.04
     tags:
       - 7.2.1-ubuntu-20.04
       - 7.2-ubuntu-20.04
-      - 7-ubuntu-20.04
     build-args:
       - FRR_TAG=frr-7.2.1
       - OS_VERSION=20.04
-  -
-    name: FRR 7.3.1 for Ubuntu 19.10
-    tags:
-      - 7.3.1-ubuntu-19.10
-      - 7.3-ubuntu-19.10
-    build-args:
-      - FRR_TAG=frr-7.3.1
-  -
-    name: FRR 7.3.1 for Ubuntu 20.04
+  - name: FRR 7.3.1 for Ubuntu 20.04
     tags:
       - 7.3.1-ubuntu-20.04
       - 7.3-ubuntu-20.04
     build-args:
       - FRR_TAG=frr-7.3.1
+      - OS_VERSION=20.04
+  - name: FRR 7.4.0 for Ubuntu 20.04
+    tags:
+      - 7.4.0-ubuntu-20.04
+      - 7.4-ubuntu-20.04
+    build-args:
+      - FRR_TAG=frr-7.4
       - OS_VERSION=20.04


### PR DESCRIPTION
- build frr-7.4
- remove builds for ubuntu-19.10 because EOL
- do not tag… frr-7.2.1 as frr-7 anymore, consumers must specify exact version